### PR TITLE
Support nil in SPARQL S-expressions

### DIFF
--- a/lib/sxp/reader/sparql.rb
+++ b/lib/sxp/reader/sparql.rb
@@ -10,6 +10,7 @@ module SXP; class Reader
   class SPARQL < Extended
     FALSE     = /^false$/i
     TRUE      = /^true$/i
+    NIL       = /^nil$/i
     EXPONENT  = /[eE][+-]?[0-9]+/
     DECIMAL   = /^[+-]?(\d*)?\.\d*#{EXPONENT}?$/
     BNODE_ID  = /^_:([A-Za-z][A-Za-z0-9]*)/ # FIXME
@@ -66,6 +67,7 @@ module SXP; class Reader
         when '.'       then buffer.to_sym
         when FALSE     then RDF::Literal(false)
         when TRUE      then RDF::Literal(true)
+        when NIL       then nil
         when DECIMAL   then RDF::Literal(Float(buffer[-1].eql?(?.) ? buffer + '0' : buffer))
         when INTEGER   then RDF::Literal(Integer(buffer))
         when BNODE_ID  then RDF::Node($1)

--- a/spec/sparql_spec.rb
+++ b/spec/sparql_spec.rb
@@ -8,6 +8,12 @@ describe SXP::Reader::SPARQL do
     end
   end
 
+  context "when reading nil" do
+    it "reads 'nil' as nil" do
+      read(%q(nil)).should be_nil
+    end
+  end
+
   context "when reading plain literals" do
     it "reads '\"\"' as a plain string literal" do
       read(%q("")).should == RDF::Literal("")


### PR DESCRIPTION
We need this to process nil bindings (i.e. for OPTIONAL clauses)
