### PR TITLE
Fix odd bug, where SXP.read_file and SXP.read_url

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ script: "bundle exec rspec spec"
 env:
   - CI=true
 rvm:
-  - 2.2.5
-  - 2.3.1
-  - jruby-9.1.2.0
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
+  - jruby
   - rbx
 cache: bundler
 sudo: false
 matrix:
   allow_failures:
+    - rvm: jruby
     - rvm: rbx

--- a/README.md
+++ b/README.md
@@ -104,8 +104,6 @@ Resources
 * <http://rubydoc.info/gems/sxp>
 * <http://github.com/dryruby/sxp>
 * <http://rubygems.org/gems/sxp>
-* <http://rubyforge.org/projects/sxp/>
-* <http://raa.ruby-lang.org/project/sxp>
 
 Authors
 -------
@@ -128,4 +126,3 @@ information, see <http://unlicense.org/> or the accompanying UNLICENSE file.
 [Scheme]:       http://scheme.info/
 [Common Lisp]:  http://en.wikipedia.org/wiki/Common_Lisp
 [SPARQL]:       http://openjena.org/wiki/SSE
-[Backports]:    http://rubygems.org/gems/backports

--- a/lib/sxp/reader.rb
+++ b/lib/sxp/reader.rb
@@ -24,7 +24,7 @@ module SXP
     # @return [Enumerable<Object>]
     def self.read_url(url, options = {})
       require 'open-uri'
-      open(url.to_s, 'rb', nil, options) { |io| read_all(io, options).first }
+      open(url.to_s, 'rb', nil, options) { |io| read_all(io, options) }
     end
 
     ##
@@ -52,7 +52,7 @@ module SXP
     #   See {#read}
     # @return [Enumerable<Object>]
     def self.read_file(filename, options = {})
-      File.open(filename.to_s, 'rb') { |io| read_all(io, options).first }
+      File.open(filename.to_s, 'rb') { |io| read_all(io, options) }
     end
 
     ##

--- a/spec/reader_spec.rb
+++ b/spec/reader_spec.rb
@@ -58,6 +58,16 @@ describe SXP::Reader::Basic do
     end
   end
 
+  it ".read_file" do
+    expect(File).to receive(:open).with("foo.sxp", "rb").and_yield(StringIO.new("(1 2 3)\n(4 5 6)"))
+    expect(SXP.read_file("foo.sxp")).to eq [[1, 2, 3], [4, 5, 6]]
+  end
+
+  it ".read_url" do
+    expect(File).to receive(:open).with("http://example/foo.sxp", "rb").and_yield(StringIO.new("(1 2 3)\n(4 5 6)"))
+    expect(SXP.read_file("http://example/foo.sxp")).to eq [[1, 2, 3], [4, 5, 6]]
+  end
+
   def read(input, options = {})
     SXP::Reader::Basic.read(input.freeze, options)
   end


### PR DESCRIPTION
were only returning the first expression read. This was likely an over-simplification for when the file contained only a single expression, and we didn't want to see this contained within an array.

@bendiken, if something relies on the old behavior, we could return the first expression if the result contains only a single expression, but that would seem to be less consistent behavior.

Fixes #14