### PR TITLE
Link updates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,2 @@
 * Arto Bendiken <arto@bendiken.net>
-* Gregg Kellogg <gregg@kellogg-assoc.com>
+* Gregg Kellogg <gregg@greggkellogg.net>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This is a Ruby implementation of a universal [S-expression][] parser.
 
-[![Gem Version](https://badge.fury.io/rb/sxp.png)](http://badge.fury.io/rb/sxp)
-[![Build Status](https://travis-ci.org/dryruby/sxp.rb.png?branch=master)](http://travis-ci.org/dryruby/sxp.rb)
+[![Gem Version](https://badge.fury.io/rb/sxp.png)](https:/badge.fury.io/rb/sxp)
+[![Build Status](https://travis-ci.org/dryruby/sxp.rb.png?branch=master)](https:/travis-ci.org/dryruby/sxp.rb)
 
 ## Features
 
@@ -44,7 +44,7 @@ This is a Ruby implementation of a universal [S-expression][] parser.
 
     require 'rdf'
 
-    SXP::Reader::SPARQL.read %q((base <http://ar.to/>))  #=> [:base, RDF::URI('http://ar.to/')]
+    SXP::Reader::SPARQL.read %q((base <https://ar.to/>))  #=> [:base, RDF::URI('https://ar.to/')]
 
 ### Writing an SXP with formatting
 
@@ -52,7 +52,7 @@ This is a Ruby implementation of a universal [S-expression][] parser.
   
 ## Documentation
 
-* Full documentation available on [RubyDoc](http://rubydoc.info/gems/sxp/file/README.md)
+* Full documentation available on [RubyDoc](https:/rubydoc.info/gems/sxp/file/README.md)
 
 * {SXP}
 
@@ -74,14 +74,14 @@ This is a Ruby implementation of a universal [S-expression][] parser.
 Dependencies
 ------------
 
-* [Ruby](http://ruby-lang.org/) (>= 2.4)
-* [RDF.rb](http://rubygems.org/gems/rdf) (~> 3.1), only needed for SPARQL
+* [Ruby](https:/ruby-lang.org/) (>= 2.4)
+* [RDF.rb](https:/rubygems.org/gems/rdf) (~> 3.1), only needed for SPARQL
   S-expressions
 
 Installation
 ------------
 
-The recommended installation method is via [RubyGems](http://rubygems.org/).
+The recommended installation method is via [RubyGems](https:/rubygems.org/).
 To install the latest official release of the SXP.rb gem, do:
 
     % [sudo] gem install sxp
@@ -96,33 +96,33 @@ To get a local working copy of the development repository, do:
 Alternatively, you can download the latest development version as a tarball
 as follows:
 
-    % wget http://github.com/dryruby/sxp.rb/tarball/master
+    % wget https:/github.com/dryruby/sxp.rb/tarball/master
 
 Resources
 ---------
 
-* <http://rubydoc.info/gems/sxp.rb>
-* <http://github.com/dryruby/sxp.rb>
-* <http://rubygems.org/gems/sxp.rb>
+* <https://rubydoc.info/gems/sxp.rb>
+* <https://github.com/dryruby/sxp.rb>
+* <https://rubygems.org/gems/sxp.rb>
 
 Authors
 -------
 
-* [Arto Bendiken](https://github.com/bendiken) - <http://ar.to/>
-* [Gregg Kellogg](http://github.com/gkellogg) - <http://greggkellogg.net/>
+* [Arto Bendiken](https://github.com/artob) - <https://ar.to/>
+* [Gregg Kellogg](https://github.com/gkellogg) - <https://greggkellogg.net/>
 
 Contributors
 ------------
 
-* [Ben Lavender](https://github.com/bhuga) - <http://bhuga.net/>
+* [Ben Lavender](https://github.com/bhuga) - <https://bhuga.net/>
 
 License
 -------
 
 SXP.rb is free and unencumbered public domain software. For more
-information, see <http://unlicense.org/> or the accompanying UNLICENSE file.
+information, see <https://unlicense.org/> or the accompanying UNLICENSE file.
 
-[S-expression]: http://en.wikipedia.org/wiki/S-expression
-[Scheme]:       http://scheme.info/
-[Common Lisp]:  http://en.wikipedia.org/wiki/Common_Lisp
+[S-expression]: https://en.wikipedia.org/wiki/S-expression
+[Scheme]:       https://scheme.info/
+[Common Lisp]:  https://en.wikipedia.org/wiki/Common_Lisp
 [SPARQL]:       https://jena.apache.org/documentation/notes/sse.html

--- a/UNLICENSE
+++ b/UNLICENSE
@@ -21,4 +21,4 @@ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
-For more information, please refer to <http://unlicense.org/>
+For more information, please refer to <https:/unlicense.org/>

--- a/etc/doap.ttl
+++ b/etc/doap.ttl
@@ -1,8 +1,8 @@
-@base <http://rubygems.org/gems/sxp> .
-@prefix dc: <http://purl.org/dc/terms/> .
+@base         <https://rubygems.org/gems/sxp> .
+@prefix dc:   <http://purl.org/dc/terms/> .
 @prefix doap: <http://usefulinc.com/ns/doap#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
 
@@ -17,31 +17,23 @@
     subset of the IEEE Scheme and DSSSL standards.
    """@en;
    doap:implements <http://dbpedia.org/resource/S-expression>;
-   doap:developer <http://ar.to/#self>, <http://greggkellogg.net/foaf#me>;
-   doap:maintainer <http://ar.to/#self>, <http://greggkellogg.net/foaf#me>;
-   doap:documenter <http://ar.to/#self>, <http://greggkellogg.net/foaf#me>;
-   dc:creator <http://ar.to/#self>;
-   foaf:maker <http://ar.to/#self>;
-   doap:bug-database <http://github.com/bendiken/sxp-ruby/issues>;
-   doap:category <http://rubyforge.org/softwaremap/trove_list.php?form_cat=20>,
-     <http://rubyforge.org/softwaremap/trove_list.php?form_cat=87>,
-     <http://rubyforge.org/softwaremap/trove_list.php?form_cat=45>,
-     <http://rubyforge.org/softwaremap/trove_list.php?form_cat=306>,
-     <http://rubyforge.org/softwaremap/trove_list.php?form_cat=242>,
-     <http://rubyforge.org/softwaremap/trove_list.php?form_cat=170>;
+   doap:developer <https://ar.to/#self>, <https://greggkellogg.net/foaf#me>;
+   doap:maintainer <https://greggkellogg.net/foaf#me>;
+   doap:documenter <https://ar.to/#self>, <https://greggkellogg.net/foaf#me>;
+   dc:creator <https://ar.to/#self>;
+   foaf:maker <https://ar.to/#self>;
+   doap:bug-database <https://github.com/dryruby/sxp.rb/issues>;
    doap:created "2007-02-26"^^xsd:date;
-   doap:homepage <http://github.com/bendiken/sxp-ruby>;
-   doap:license <http://creativecommons.org/licenses/publicdomain/>;
-   doap:platform "Ruby" .
+   doap:homepage <https://github.com/dryruby/sxp.rb>;
+   doap:license <http://creativecommons.org/publicdomain/zero/1.0/>;
+   doap:programming-language "Ruby" .
 
-<http://greggkellogg.net/foaf#me> a foaf:Person;
-   foaf:homepage <http://greggkellogg.net/>;
+<https://greggkellogg.net/foaf#me> a foaf:Person;
+   foaf:homepage <https://greggkellogg.net/>;
    foaf:mbox <mailto:gregg@greggkellogg.net>;
    foaf:name "Gregg Kellogg" .
 
-<http://ar.to/#self> a foaf:Person;
-   rdfs:isDefinedBy <http://datagraph.org/bendiken/foaf>;
-   foaf:homepage <http://ar.to/>;
+<https://ar.to/#self> a foaf:Person;
+   foaf:homepage <https://ar.to/>;
    foaf:mbox <mailto:arto@bendiken.net>;
-   rdfs:seeAlso <http://rubyforge.org/users/arto/>;
    foaf:name "Arto Bendiken" .

--- a/etc/doap.ttl
+++ b/etc/doap.ttl
@@ -25,7 +25,7 @@
    doap:bug-database <https://github.com/dryruby/sxp.rb/issues>;
    doap:created "2007-02-26"^^xsd:date;
    doap:homepage <https://github.com/dryruby/sxp.rb>;
-   doap:license <http://creativecommons.org/publicdomain/zero/1.0/>;
+   doap:license <http://unlicense.org/>;
    doap:programming-language "Ruby" .
 
 <https://greggkellogg.net/foaf#me> a foaf:Person;

--- a/lib/sxp.rb
+++ b/lib/sxp.rb
@@ -1,20 +1,6 @@
 require 'rational'
 require 'stringio'
 
-if RUBY_VERSION < '1.8.7'
-  # @see http://rubygems.org/gems/backports
-  begin
-    require 'backports/1.8.7'
-  rescue LoadError
-    begin
-      require 'rubygems'
-      require 'backports/1.8.7'
-    rescue LoadError
-      abort "SXP.rb requires Ruby 1.8.7 or the Backports gem (hint: `gem install backports')."
-    end
-  end
-end
-
 require 'sxp/version'
 require 'sxp/extensions'
 require 'sxp/writer'

--- a/lib/sxp/pair.rb
+++ b/lib/sxp/pair.rb
@@ -27,7 +27,7 @@ module SXP
     # Returns `true` if the tail of this pair is not `nil` or another pair.
     #
     # @return [Boolean]
-    # @see    http://srfi.schemers.org/srfi-1/srfi-1.html#ImproperLists
+    # @see    https:/srfi.schemers.org/srfi-1/srfi-1.html#ImproperLists
     def dotted?
       !proper?
     end
@@ -36,7 +36,7 @@ module SXP
     # Returns `true` if the tail of this pair is `nil` or another pair.
     #
     # @return [Boolean]
-    # @see    http://srfi.schemers.org/srfi-1/srfi-1.html#ImproperLists
+    # @see    https:/srfi.schemers.org/srfi-1/srfi-1.html#ImproperLists
     def proper?
       tail.nil? || tail.is_a?(Pair)
     end

--- a/lib/sxp/reader/common_lisp.rb
+++ b/lib/sxp/reader/common_lisp.rb
@@ -3,7 +3,7 @@ module SXP; class Reader
   ##
   # A Common Lisp S-expressions parser.
   #
-  # @see http://www.cs.cmu.edu/Groups/AI/html/cltl/clm/node14.html
+  # @see https:/www.cs.cmu.edu/Groups/AI/html/cltl/clm/node14.html
   class CommonLisp < Basic
     OPTIONS         = {nil: nil, t: true, quote: :quote, function: :function}
 
@@ -16,7 +16,7 @@ module SXP; class Reader
 
     # Escape characters, used in the form `#\Backspace`. Case is treated
     # insensitively
-    # @see http://www.cs.cmu.edu/Groups/AI/html/cltl/clm/node22.html
+    # @see https:/www.cs.cmu.edu/Groups/AI/html/cltl/clm/node22.html
     CHARACTERS = {
       'newline'   => "\n",
       'space'     => " ",
@@ -114,7 +114,7 @@ module SXP; class Reader
     # eroneously read characters back in the input stream
     #
     # @return [String]
-    # @see    http://www.cs.cmu.edu/Groups/AI/html/cltl/clm/node22.html
+    # @see    https:/www.cs.cmu.edu/Groups/AI/html/cltl/clm/node22.html
     def read_character
       lit = read_literal
 

--- a/lib/sxp/reader/scheme.rb
+++ b/lib/sxp/reader/scheme.rb
@@ -3,7 +3,7 @@ module SXP; class Reader
   ##
   # A Scheme R4RS S-expressions parser.
   #
-  # @see http://people.csail.mit.edu/jaffer/r4rs_9.html#SEC65
+  # @see https:/people.csail.mit.edu/jaffer/r4rs_9.html#SEC65
   class Scheme < Extended
     DECIMAL         = /^[+-]?(\d*)?\.\d*$/
     INTEGER_BASE_2  = /^[+-]?[01]+$/
@@ -14,7 +14,7 @@ module SXP; class Reader
 
     # Escape characters, used in the form `#\newline`. Case is treated
     # insensitively
-    # @see http://people.csail.mit.edu/jaffer/r4rs_9.html#SEC65
+    # @see https:/people.csail.mit.edu/jaffer/r4rs_9.html#SEC65
     CHARACTERS = {
       'newline'   => "\n",
       'space'     => " ",
@@ -76,7 +76,7 @@ module SXP; class Reader
     # eroneously read characters back in the input stream
     #
     # @return [String]
-    # @see    http://people.csail.mit.edu/jaffer/r4rs_9.html#SEC65
+    # @see    https:/people.csail.mit.edu/jaffer/r4rs_9.html#SEC65
     def read_character
       lit = read_literal
 

--- a/lib/sxp/reader/sparql.rb
+++ b/lib/sxp/reader/sparql.rb
@@ -1,13 +1,13 @@
 # -*- encoding: utf-8 -*-
-require 'rdf' # @see http://rubygems.org/gems/rdf
+require 'rdf' # @see https:/rubygems.org/gems/rdf
 
 module SXP; class Reader
   ##
   # A SPARQL Syntax Expressions (SSE) parser.
   #
-  # Requires [RDF.rb](http://rdf.rubyforge.org/).
+  # Requires [RDF.rb](https:/rubygems.org/gems/rdf/).
   #
-  # @see http://openjena.org/wiki/SSE
+  # @see https:/openjena.org/wiki/SSE
   class SPARQL < Extended
     # Alias for rdf:type
     A         = /^a$/
@@ -83,12 +83,12 @@ module SXP; class Reader
     end
 
     ##
-    # Reads SSE Tokens, including {RDF::Literal}, {RDF::URI} and RDF::Node.
+    # Reads SSE Tokens, including `RDF::Literal`, `RDF::URI` and `RDF::Node`.
     #
     # Performs forward reference for prefix and base URI representations and saves in
     # {#base_uri} and {#prefixes} accessors.
     #
-    # Transforms tokens matching a {PNAME} pattern into {RDF::URI} instances if a match is
+    # Transforms tokens matching a {PNAME} pattern into `RDF::URI` instances if a match is
     # found with a previously identified {PREFIX}.
     # @return [Object]
     def read_token
@@ -211,7 +211,7 @@ module SXP; class Reader
     #
     # Atoms parsed including `base`, `prefix`, `true`, `false`, numeric, BNodes and variables.
     #
-    # Creates {RDF::Literal}, RDF::Node, or {RDF::Query::Variable} instances where appropriate.
+    # Creates `RDF::Literal`, `RDF::Node`, or `RDF::Query::Variable` instances where appropriate.
     #
     # @return [Object]
     def read_atom

--- a/sxp.gemspec
+++ b/sxp.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |gem|
   gem.date               = File.mtime('VERSION').strftime('%Y-%m-%d')
 
   gem.name               = 'sxp'
-  gem.homepage           = 'http://sxp.rubyforge.org/'
+  gem.homepage           = 'https://github.com/dryruby/sxp/'
   gem.license            = 'Unlicense'
   gem.summary            = 'A pure-Ruby implementation of a universal S-expression parser.'
   gem.description        = 'Universal S-expression parser with specific support for Common Lisp, Scheme, and RDF/SPARQL'


### PR DESCRIPTION
Note this updates `doap:license` to `http://unlicense.org/` from `http://creativecommons.org/licenses/publicdomain/` that latter is obsolete, and they now recommend `http://creativecommons.org/publicdomain/zero/1.0/`.

It would be better if there were a versioned license URI from http://unlicense.org/.

See https://github.com/unlicense/unlicense.org/issues/74